### PR TITLE
Bump runtime and update to 4.2.1

### DIFF
--- a/com.airtame.Client.appdata.xml
+++ b/com.airtame.Client.appdata.xml
@@ -26,6 +26,40 @@
   </categories>
   <!-- https://help.airtame.com/product-roadmap-and-changes/product-changes/product-changes-overview -->
   <releases>
+    <release version="4.2.1" date="2021-07-05">
+      <description>
+        <p>Bug fixes</p>
+          <ul>
+            <li>Fixed an issue where the app would crash when attempting to stream to an offline device</li>
+          </ul>
+      </description>
+    </release>
+    <release version="4.2.0" date="2021-06-07">
+      <description>
+        <p>Improvements</p>
+          <ul>
+            <li>Streaming via the Airtame app (native Airtame protocol) now utilizes TCP as a transport layer protocol instead of ENET on UDP. This should lead to increased performance when screen sharing, in particular during video playback</li>
+          </ul>
+        <p>Bug fixes</p>
+          <ul>
+            <li>Fixed the issue when a stream would not start from a source device with an odd resolution (e.g. 1904x949)</li>
+          </ul>
+      </description>
+    </release>
+    <release version="4.1.1" date="2020-08-17">
+      <description>
+        <p>Improvements</p>
+          <ul>
+            <li>Allow analytics to use system proxy</li>
+            <li>Improve the analytics retry mechanism (in case an analytics event failed to be sent)</li>
+          </ul>
+        <p>Bug fixes</p>
+          <ul>
+            <li>Fix for the missing tray icon on Windows when dark mode is enabled for applications</li>
+            <li>Fix for the app getting stuck in the Setup Flow when trying to connect to a device</li>
+          </ul>
+      </description>
+    </release>
     <release version="4.1.0" date="2020-06-30">
       <description>
         <p>New features</p>

--- a/com.airtame.Client.appdata.xml
+++ b/com.airtame.Client.appdata.xml
@@ -24,7 +24,7 @@
   <categories>
     <category>Utility</category>
   </categories>
-  <!-- https://help.airtame.com/product-roadmap-and-changes/product-changes/product-changes-overview -->
+  <!-- https://help.airtame.com/hc/en-us/articles/5348392729117-Changelog-Product-Changes-Airtame-Application- -->
   <releases>
     <release version="4.2.1" date="2021-07-05">
       <description>

--- a/com.airtame.Client.json
+++ b/com.airtame.Client.json
@@ -1,13 +1,16 @@
 {
   "app-id": "com.airtame.Client",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "19.08",
+  "runtime-version": "21.08",
   "sdk": "org.freedesktop.Sdk",
-  "base": "io.atom.electron.BaseApp",
-  "base-version": "19.08",
+  "base": "org.electronjs.Electron2.BaseApp",
+  "base-version": "21.08",
   "command": "airtame",
+  "separate-locales": false,
   "finish-args": [
     "--share=ipc",
+    "--device=dri",
+    "--socket=pulseaudio",
     "--socket=x11",
     "--share=network"
   ],
@@ -43,7 +46,7 @@
           "type": "script",
           "dest-filename": "airtame.sh",
           "commands": [
-            "exec /app/extra/Airtame/airtame-application --no-sandbox \"$@\""
+            "zypak-wrapper /app/extra/Airtame/airtame-application \"$@\""
           ]
         },
         {
@@ -56,9 +59,9 @@
           "only-arches": [
             "x86_64"
           ],
-          "url": "https://downloads-cdn.airtame.com/app/latest/linux/Airtame-4.1.0.deb",
-          "sha256": "7c48e637cdde10868f7e550ad1c6eb285db6c9f9af996c123b7d02b3a2d78b4d",
-          "size": 58558948
+          "url": "https://downloads-cdn.airtame.com/app/latest/linux/Airtame-4.2.1.deb",
+          "sha256": "6a7258bc4d4f906383226d244a5699d0959ad547b781906a491038cdb302028a",
+          "size": 60865516
         }
       ]
     }


### PR DESCRIPTION
20.08 will be EOL'd in August, ideally we want 21.08 but the Electron baseapp doesn't have a 21.08 branch right now. I'll update it once the branch is created.

I couldn't find the official release date anywhere or the release notes. https://help.airtame.com/product-roadmap-and-changes/product-changes/product-changes-overview seems to be gone.

cc @klausenbusk, please review when you have time. Thanks!